### PR TITLE
Maps sdk as plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
       "ios": "1.5.1"
     }
   },
+  "dependencies": {
+    "nativescript-plugin-google-play-services": "26.0.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -29,7 +32,6 @@
     "url": "https://github.com/dapriett/nativescript-google-maps-sdk/issues"
   },
   "homepage": "https://github.com/dapriett/nativescript-google-maps-sdk#readme",
-  "dependencies": {},
   "devDependencies": {
     "tns-core-modules": "^1.5.1",
     "typescript": "^1.7.5"

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -6,6 +6,3 @@ android {
 	}
 }
 
-dependencies {
-	compile 'com.google.android.gms:play-services-maps:+'
-}


### PR DESCRIPTION
Hi mate,

Several users hit the same issue of duplicate dependency on Google Play services when linking in several plugins depending on them. This change lets us use Gradle dependency resolution to avoid duplicates. Please consider merging in.

Cheers,
Aleksey