### PR TITLE
Fix Webpack issue that breaks with TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "removeComments": true,
         "noLib": false,
         "preserveConstEnums": true,
-        "suppressImplicitAnyIndexErrors": true
+        "suppressImplicitAnyIndexErrors": true,
+        "noEmitHelpers": true,
     },
     
     "filesGlob": [


### PR DESCRIPTION
Adding `noEmitHelpers` to TypeScript avoid the creating of the `__extends()` function which breaks WebPack.

Read more: 
https://github.com/NativeScript/nativescript-dev-webpack/issues/8
http://stackoverflow.com/questions/36556772/webpack-and-typescript-extends