### PR TITLE
Set Latitude and Longitude as Float

### DIFF
--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -298,7 +298,7 @@ export class Position extends PositionBase {
     }
 
     set latitude(latitude) {
-        this._android = new com.google.android.gms.maps.model.LatLng(latitude, this.longitude);
+        this._android = new com.google.android.gms.maps.model.LatLng(parseFloat(latitude), this.longitude);
     }
 
     get longitude() {
@@ -306,7 +306,7 @@ export class Position extends PositionBase {
     }
 
     set longitude(longitude) {
-        this._android = new com.google.android.gms.maps.model.LatLng(this.latitude, longitude);
+        this._android = new com.google.android.gms.maps.model.LatLng(this.latitude, parseFloat(longitude));
     }
 
     constructor(android?:com.google.android.gms.maps.model.LatLng) {


### PR DESCRIPTION
We spent some time looking into a fix for issue #53 and noticed that on Android the Longitude and Latitude needs to be parsed as a float in oder to work.