### PR TITLE
Implement `shapeSelect` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Event          | Description
 -------------- |:---------------------------------
 `mapReady`     | Called when Google Map is ready for use
 `coordinateTapped` | Fires when coordinate is clicked on map
+`coordinateLongPress` | Fires when coordinate is "long pressed"
 `markerSelect` | Fires whenever a marker is selected
 `markerBeginDragging` | Fires when a marker begins dragging
 `markerDrag` | Fires repeatedly while a marker is being dragged

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Event          | Description
 `coordinateTapped` | Fires when coordinate is clicked on map
 `coordinateLongPress` | Fires when coordinate is "long pressed"
 `markerSelect` | Fires whenever a marker is selected
+`shapeSelect` | Fires whenever a shape (`Circle`, `Polygon`, `Polyline`) is clicked.  You must explicity configure `shape.clickable = true;` on your shapes.
 `markerBeginDragging` | Fires when a marker begins dragging
 `markerDrag` | Fires repeatedly while a marker is being dragged
 `markerEndDragging` | Fires when a marker ends dragging

--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -28,6 +28,7 @@ export abstract class MapView extends View implements IMapView {
     public static markerEndDraggingEvent: string = "markerEndDragging";
     public static markerDragEvent: string = "markerDrag";
     public static coordinateTappedEvent: string = "coordinateTapped";
+    public static coordinateLongPressEvent: string = "coordinateLongPress";
     public static cameraChangedEvent: string = "cameraChanged";
 
     public static latitudeProperty = new Property("latitude", MAP_VIEW, new PropertyMetadata(0, PropertyMetadataSettings.None, onMapPropertyChanged));

--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -1,4 +1,4 @@
-import { MapView as IMapView, Position as IPosition, Marker as IMarker, Shape as IShape, Polyline as IPolyline, Polygon as IPolygon, Circle as ICircle, Camera, MarkerEventData, CameraEventData, PositionEventData } from ".";
+import { MapView as IMapView, Position as IPosition, Marker as IMarker, Shape as IShape, Polyline as IPolyline, Polygon as IPolygon, Circle as ICircle, Camera, MarkerEventData, ShapeEventData, CameraEventData, PositionEventData } from ".";
 import { View } from "ui/core/view";
 import { Image } from "ui/image";
 
@@ -24,6 +24,7 @@ export abstract class MapView extends View implements IMapView {
 
     public static mapReadyEvent: string = "mapReady";
     public static markerSelectEvent: string = "markerSelect";
+    public static shapeSelectEvent: string = "shapeSelect";
     public static markerBeginDraggingEvent: string = "markerBeginDragging";
     public static markerEndDraggingEvent: string = "markerEndDragging";
     public static markerDragEvent: string = "markerDrag";
@@ -156,10 +157,17 @@ export abstract class MapView extends View implements IMapView {
         this.notify(args);
     }
 
+    notifyShapeEvent(eventName: string, shape: IShape) {
+        let args: ShapeEventData = { eventName: eventName, object: this, shape: shape };
+        this.notify(args);
+    }
     notifyMarkerTapped(marker: Marker) {
         this.notifyMarkerEvent(MapView.markerSelectEvent, marker);
     }
 
+    notifyShapeTapped(shape: Shape) {
+        this.notifyShapeEvent(MapView.shapeSelectEvent, shape);
+    }
     notifyMarkerBeginDragging(marker: Marker) {
         this.notifyMarkerEvent(MapView.markerBeginDraggingEvent, marker);
     }
@@ -200,6 +208,7 @@ export class Marker implements IMarker {
 export class Shape implements IShape {
     public shape: string;
     public userData: any;
+    public clickable: boolean;
 }
 
 export class Polyline extends Shape implements IPolyline {

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -218,10 +218,39 @@ export class MapView extends MapViewCommon {
 
                 gMap.setOnMarkerClickListener(new com.google.android.gms.maps.GoogleMap.OnMarkerClickListener({
                     onMarkerClick: function(gmsMarker) {
-
                         let marker: Marker = owner.findMarker((marker: Marker) => marker.android.getId() === gmsMarker.getId());
                         owner.notifyMarkerTapped(marker);
 
+                        return false;
+                    }
+                }));
+
+                gMap.setOnCircleClickListener(new com.google.android.gms.maps.GoogleMap.OnCircleClickListener({
+                    onCircleClick: function(gmsCircle) {
+                        let shape: Shape = owner.findShape((shape: Shape) => shape.android.getId() === gmsCircle.getId());
+                        if (shape) {
+                            owner.notifyShapeTapped(shape);
+                        }
+                        return false;
+                    }
+                }));
+
+                gMap.setOnPolylineClickListener(new com.google.android.gms.maps.GoogleMap.OnPolylineClickListener({
+                    onPolylineClick: function(gmsPolyline) {
+                        let shape: Shape = owner.findShape((shape: Shape) => shape.android.getId() === gmsPolyline.getId());
+                        if (shape) {
+                            owner.notifyShapeTapped(shape);
+                        }
+                        return false;
+                    }
+                }));
+
+                gMap.setOnPolygonClickListener(new com.google.android.gms.maps.GoogleMap.OnPolygonClickListener({
+                    onPolygonClick: function(gmsPolygon) {
+                        let shape: Shape = owner.findShape((shape: Shape) => shape.android.getId() === gmsPolygon.getId());
+                        if (shape) {
+                            owner.notifyShapeTapped(shape);
+                        }
                         return false;
                     }
                 }));
@@ -494,6 +523,18 @@ export class Polyline extends PolylineBase {
         this._points = [];
     }
 
+    get clickable() {
+        return this._android.isClickable();
+    }
+
+    set clickable(value: boolean) {
+        if (this._isReal) {
+            this._android.setClickable(value);
+        } else {
+            this._android.clickable(value);
+        }
+    }
+
     get zIndex() {
         return this._android.getZIndex();
     }
@@ -617,6 +658,18 @@ export class Circle extends CircleBase {
     constructor() {
         super();
         this.android = new com.google.android.gms.maps.model.CircleOptions();
+    }
+
+    get clickable() {
+        return this._android.isClickable();
+    }
+
+    set clickable(value: boolean) {
+        if (this._isReal) {
+            this._android.setClickable(value);
+        } else {
+            this._android.clickable(value);
+        }
     }
 
     get zIndex() {

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -209,6 +209,13 @@ export class MapView extends MapViewCommon {
                     }
                 }));
 
+                gMap.setOnMapLongClickListener(new com.google.android.gms.maps.GoogleMap.OnMapLongClickListener({
+                    onMapLongClick: function(gmsPoint) {
+                        let position: Position = new Position(gmsPoint);
+                        owner.notifyPositionEvent(MapViewCommon.coordinateLongPressEvent, position);
+                    }
+                }));
+
                 gMap.setOnMarkerClickListener(new com.google.android.gms.maps.GoogleMap.OnMarkerClickListener({
                     onMarkerClick: function(gmsMarker) {
 

--- a/map-view.d.ts
+++ b/map-view.d.ts
@@ -132,6 +132,10 @@ declare module "nativescript-google-maps-sdk" {
         marker: Marker;
     }
 
+    export interface ShapeEventData extends EventData {
+        shape: Shape;
+    }
+
     export interface CameraEventData extends EventData {
         camera: Camera;
     }

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -82,6 +82,15 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
         }
     }
 
+    public mapViewDidTapOverlay(mapView: GMSMapView, gmsOverlay: GMSOverlay): void {
+        let owner = this._owner.get();
+        if (owner) {
+            let shape: Shape = owner.findShape((shape: Shape) => shape.ios == gmsOverlay);
+            if (shape) {
+                owner.notifyShapeTapped(shape);
+            }
+        }
+    }
     public mapViewDidBeginDraggingMarker(mapView: GMSMapView, gmsMarker: GMSMarker): void {
         let owner = this._owner.get();
         if (owner) {
@@ -210,7 +219,7 @@ export class MapView extends MapViewCommon {
     }
 
     findShape(callback: (shape: Shape) => boolean): Shape {
-        return this._markers.find(callback);
+        return this._shapes.find(callback);
     }
 
     clear() {
@@ -358,6 +367,14 @@ export class Polyline extends PolylineBase {
         this._points = [];
     }
 
+    get clickable() {
+        return this._ios.tappable;
+    }
+
+    set clickable(value: boolean) {
+        this._ios.tappable = value;
+    }
+
     get zIndex() {
         return this._ios.zIndex;
     }
@@ -435,6 +452,14 @@ export class Circle extends CircleBase {
     constructor() {
         super();
         this._ios = GMSCircle.new();
+    }
+
+    get clickable() {
+        return this._ios.tappable;
+    }
+
+    set clickable(value: boolean) {
+        this._ios.tappable = value;
     }
 
     get zIndex() {

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -66,6 +66,14 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
         }
     }
 
+    public mapViewDidLongPressAtCoordinate(mapView: GMSMapView, coordinate: CLLocationCoordinate2D): void {
+        let owner = this._owner.get();
+        if (owner) {
+            let position: Position = Position.positionFromLatLng(coordinate.latitude, coordinate.longitude);
+            owner.notifyPositionEvent(MapViewCommon.coordinateLongPressEvent, position);
+        }
+    }
+
     public mapViewDidTapMarker(mapView: GMSMapView, gmsMarker: GMSMarker): void {
         let owner = this._owner.get();
         if (owner) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,12 @@
         "./**/*.ts",
         "!./node_modules/**/*.ts"
     ],
-    
+    "files": [
+        "map-view.d.ts",
+        "map-view-common.ts",
+        "map-view.android.ts",
+        "map-view.ios.ts"
+    ],
     "exclude": [
         "./platforms/**/*.ts"
     ]


### PR DESCRIPTION
- Implements `Shape` click-listeners for `Circle`, `Polyline` and `Polygon`.  
- Added `@property {Boolean} clickable` on `Shape`.  Both iOS and Android default "clickability" on shapes to `false`.