### PR TITLE
Added "infowindowTap" Event, now you can handle Taps on an Infowindow

### DIFF
--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -24,6 +24,7 @@ export abstract class MapView extends View implements IMapView {
 
     public static mapReadyEvent: string = "mapReady";
     public static markerSelectEvent: string = "markerSelect";
+    public static markerInfowindowTapEvent:string = "infowindowTap";
     public static shapeSelectEvent: string = "shapeSelect";
     public static markerBeginDraggingEvent: string = "markerBeginDragging";
     public static markerEndDraggingEvent: string = "markerEndDragging";
@@ -164,7 +165,9 @@ export abstract class MapView extends View implements IMapView {
     notifyMarkerTapped(marker: Marker) {
         this.notifyMarkerEvent(MapView.markerSelectEvent, marker);
     }
-
+    notifyMarkerInfowindowTapped (marker:Marker) {
+        this.notifyMarkerEvent(MapView.markerInfowindowTapEvent, marker);
+    }
     notifyShapeTapped(shape: Shape) {
         this.notifyShapeEvent(MapView.shapeSelectEvent, shape);
     }

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -225,6 +225,15 @@ export class MapView extends MapViewCommon {
                     }
                 }));
 
+                gMap.setOnInfoWindowClickListener(new com.google.android.gms.maps.GoogleMap.OnInfoWindowClickListener({
+                    onInfoWindowClick: function (gmsMarker) {
+                        let marker = owner.findMarker((marker: Marker) => marker.android.getId() === gmsMarker.getId());
+                        owner.notifyMarkerInfowindowTapped(marker);
+
+                        return false;
+                    }
+                }));
+
                 gMap.setOnCircleClickListener(new com.google.android.gms.maps.GoogleMap.OnCircleClickListener({
                     onCircleClick: function(gmsCircle) {
                         let shape: Shape = owner.findShape((shape: Shape) => shape.android.getId() === gmsCircle.getId());


### PR DESCRIPTION
Hello @dapriett ,
I saw this #59 Issue and i implemented it for android.
Now you can use "infowindowTap" to catch Taps on the InfoWindow.

Don't know about the IOS implementation if it is needed, i guess the code in isse 59 is correct and could also be implemented, so this feature will work for both platforms.