### PR TITLE
Add typings entry to package.json.

### DIFF
--- a/map-view.d.ts
+++ b/map-view.d.ts
@@ -122,7 +122,7 @@ declare module "nativescript-google-maps-sdk" {
         public removePoint(shape: Position): void;
         public removeAllPoints(): void;
         public getPoints(): Array<Position>;
-    };
+    }
 
     export class Polygon extends Shape {
         public points: Array<Position>;
@@ -133,7 +133,7 @@ declare module "nativescript-google-maps-sdk" {
         public removePoint(shape: Position): void;
         public removeAllPoints(): void;
         public getPoints(): Array<Position>;
-    };
+    }
 
     export class Circle extends Shape {
         public center: Position;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.13",
   "description": "Google Maps SDK plugin for Nativescript",
   "main": "map-view.js",
+  "typings": "map-view.d.ts",
   "nativescript": {
     "platforms": {
       "android": "1.5.1",


### PR DESCRIPTION
Fix Typescript errors in definition file.
Allows module to work in Typescript with:
`import {MapView, Marker, Polyline, Position} from 'nativescript-google-maps-sdk';`