### PR TITLE
fix padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,16 @@ Modify your view by adding the namespace `xmlns:maps="nativescript-google-maps-s
 </Page>
 ```
 
-The following properties `latitude`, `latitude`, `zoom`, `bearing`, `tilt` and `padding` are available to you for adjusting camera view.
+The following properties are available to you for adjusting camera view.
+
+Property       | Description
+-------------- |:---------------------------------
+`latitude` | number
+`latitude` | number
+`zoom` | number
+`bearing` | number
+`tilt` | number
+`padding` | array of numbers reflectig top, bottom, left and right paddings
 
 The following events are available:
 

--- a/demo/app/main-page.js
+++ b/demo/app/main-page.js
@@ -103,7 +103,7 @@ function onMapReady(args) {
     }).then(function () {
         polyline.addPoint(mapsModule.Position.positionFromLatLng(-33.33, 151.08));
         console.log("Adding point to Polyline...", polyline);
-        vmModule.mainViewModel.set("padding", [40, 40, 40, 40]);
+        vmModule.mainViewModel.set("padding", [30, 60, 40, 40]);
         return wait(3000);
     }).then(function () {
         polygon.addPoint(mapsModule.Position.positionFromLatLng(-34.22, 151.20));

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -84,7 +84,12 @@ export class MapView extends MapViewCommon {
 
     updatePadding() {
         if (this.padding && this.gMap) {
-            this.gMap.setPadding(this.padding[0] || 0, this.padding[1] || 0, this.padding[2] || 0, this.padding[3] || 0);
+            this.gMap.setPadding(
+                this.padding[2] || 0,
+                this.padding[0] || 0,
+                this.padding[3] || 0,
+                this.padding[1] || 0
+            );
         }
     }
 

--- a/map-view.d.ts
+++ b/map-view.d.ts
@@ -11,7 +11,6 @@ declare module "nativescript-google-maps-sdk" {
         public zoom: number;
         public bearing: number;
         public tilt: number;
-        public paddig: Array<number>;
     }
 
     export class MapView extends View {
@@ -21,12 +20,14 @@ declare module "nativescript-google-maps-sdk" {
         public static bearingProperty: Property;
         public static zoomProperty: Property;
         public static tiltProperty: Property;
+        public static paddingProperty: Property;
 
         public latitude: number;
         public longitude: number;
         public zoom: number;
         public bearing: number;
         public tilt: number;
+        public padding: Array<number>;
 
         public notifyMapReady(): void;
 

--- a/map-view.d.ts
+++ b/map-view.d.ts
@@ -11,6 +11,7 @@ declare module "nativescript-google-maps-sdk" {
         public zoom: number;
         public bearing: number;
         public tilt: number;
+        public paddig: Array<number>;
     }
 
     export class MapView extends View {

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -165,7 +165,12 @@ export class MapView extends MapViewCommon {
 
     updatePadding() {
         if (this.padding) {
-            this.gMap.padding = UIEdgeInsetsMake(this.padding[0] || 0, this.padding[1] || 0, this.padding[2] || 0, this.padding[3] || 0);
+            this.gMap.padding = UIEdgeInsetsMake(
+                this.padding[0] || 0,
+                this.padding[2] || 0,
+                this.padding[1] || 0,
+                this.padding[3] || 0
+            );
         }
     }
 


### PR DESCRIPTION
padding behavior differs between ios and android in order of side paddings
this fix unifies that order to `[top, bottom, left, right]`