### PR TITLE
Animating android camera when moving the map

### DIFF
--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -262,7 +262,7 @@ export class MapView extends MapViewBase {
         this._pendingCameraUpdate = false;
 
         var cameraUpdate = com.google.android.gms.maps.CameraUpdateFactory.newCameraPosition(cameraPosition);
-        this.gMap.moveCamera(cameraUpdate);
+        this.gMap.animateCamera(cameraUpdate);
     }
 
     setViewport(bounds:Bounds, padding?:number) {
@@ -274,7 +274,7 @@ export class MapView extends MapViewBase {
         }
 
         this._pendingCameraUpdate = false;
-        this.gMap.moveCamera(cameraUpdate);
+        this.gMap.animateCamera(cameraUpdate);
     }
 
     updatePadding() {


### PR DESCRIPTION
The iOS's implementation animates the camera when moving it, but in Android there is no animation, so I've changed `moveCamera` to `animateCamera` in the android's map-view to animate camera movement in android. 