### PR TITLE
Custom Info Window: Unload views when referring marker gets removed

### DIFF
--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -178,6 +178,13 @@ export abstract class MapViewBase extends View implements MapView {
         return view;
     }
 
+    protected _unloadInfoWindowContent(marker: MarkerBase) {
+        if (marker._infoWindowView) {
+            marker._infoWindowView.onUnloaded();
+            marker._infoWindowView = null;
+        }
+    }
+
     public _getInfoWindowTemplate(marker: MarkerBase): KeyedTemplate {
         const templateKey = marker.infoWindowTemplate;
         for (let i = 0, length = this._infoWindowTemplates.length; i < length; i++) {

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -329,6 +329,7 @@ export class MapView extends MapViewBase {
     }
 
     removeMarker(marker: Marker) {
+        this._unloadInfoWindowContent(marker);
         marker.android.remove();
         this._markers.splice(this._markers.indexOf(marker), 1);
     }

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -336,6 +336,7 @@ export class MapView extends MapViewBase {
 
     removeAllMarkers() {
         this._markers.forEach(marker => {
+            this._unloadInfoWindowContent(marker);
             marker.android.remove();
         });
         this._markers = [];

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -279,6 +279,7 @@ export class MapView extends MapViewBase {
 
     removeAllMarkers() {
         this._markers.forEach(marker => {
+            this._unloadInfoWindowContent(marker);
             marker.ios.map = null;
         });
         this._markers = [];

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -272,6 +272,7 @@ export class MapView extends MapViewBase {
     }
 
     removeMarker(marker: Marker) {
+        this._unloadInfoWindowContent(marker);
         marker.ios.map = null;
         this._markers.splice(this._markers.indexOf(marker), 1);
     }


### PR DESCRIPTION
For nativescript-angular: This allows to destroy the `ViewRef` when the info window content has been created as `EmbeddedViewRef` from an angular `TemplateRef`

Relates to #77 