### PR TITLE
[Feature] made the custom icon image compatible to tns-core-modules@3.1.0

### DIFF
--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -5,6 +5,10 @@ import {
 } from "./map-view";
 import { Point, View } from "tns-core-modules/ui/core/view";
 import { Image } from "tns-core-modules/ui/image";
+import { ImageSource } from "image-source";
+import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
+import builder = require("ui/builder");
+import frame = require("ui/frame");
 
 import { Property } from "tns-core-modules/ui/core/properties";
 import { Color } from "tns-core-modules/color";
@@ -275,7 +279,7 @@ export abstract class MarkerBase implements Marker {
     public title: string;
     public snippet: string;
     public color: Color|string|number;
-    public icon: Image|string;
+    public icon: ImageSource|string;
     public alpha: number;
     public flat: boolean;
     public draggable: boolean;

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -10,6 +10,7 @@ import {
     tiltProperty, StyleBase, UISettingsBase, getColorHue
 } from "./map-view-common";
 import { Image } from "tns-core-modules/ui/image";
+import { ImageSource } from "image-source";
 import { Color } from "tns-core-modules/color";
 import { Point } from "tns-core-modules/ui/core/view";
 import imageSource = require("tns-core-modules/image-source");
@@ -590,7 +591,7 @@ export class Bounds extends BoundsBase {
 export class Marker extends MarkerBase {
     private _android: any;
     private _color: number;
-    private _icon: Image;
+    private _icon: ImageSource;
     private _isMarker: boolean = false;
 
     static CLASS = 'com.google.android.gms.maps.model.Marker';
@@ -694,14 +695,12 @@ export class Marker extends MarkerBase {
         return this._icon;
     }
 
-    set icon(value: Image|string) {
+    set icon(value: ImageSource|string) {
         if (typeof value === 'string') {
-            var tempIcon = new Image();
-            tempIcon.imageSource = imageSource.fromResource(String(value));
-            value = tempIcon;
+            value = imageSource.fromResource(String(value));
         }
         this._icon = value;
-        var androidIcon = (value) ? com.google.android.gms.maps.model.BitmapDescriptorFactory.fromBitmap(value.imageSource.android) : null;
+        var androidIcon = (value) ? com.google.android.gms.maps.model.BitmapDescriptorFactory.fromBitmap(value.android) : null;
         if (this._isMarker) {
             this._android.setIcon(androidIcon);
         } else {

--- a/map-view.d.ts
+++ b/map-view.d.ts
@@ -1,6 +1,6 @@
 import { Point, View } from "tns-core-modules/ui/core/view";
 import { Property } from "tns-core-modules/ui/core/properties";
-import { Image } from "tns-core-modules/ui/image";
+import { ImageSource } from "image-source";
 import { Color } from "tns-core-modules/color";
 import { EventData } from "tns-core-modules/data/observable";
 
@@ -144,7 +144,7 @@ export class Marker {
     public title: string;
     public snippet: string;
     public color: Color|string|number; /* Default Icon color - either Color, string color name, string color hex, or number hue (0-360) */
-    public icon: Image|string;
+    public icon: ImageSource|string;
     public alpha: number;
     public flat: boolean;
     public draggable: boolean;

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -522,7 +522,7 @@ export class Position extends PositionBase {
 export class Marker extends MarkerBase {
     private _ios: any;
     private _color: number;
-    private _icon: Image;
+    private _icon: imageSource.ImageSource;
     private _alpha = 1;
     private _visible = true;
 
@@ -598,14 +598,12 @@ export class Marker extends MarkerBase {
         return this._icon;
     }
 
-    set icon(value: Image|string) {
+    set icon(value: imageSource.ImageSource|string) {
         if (typeof value === 'string') {
-            var tempIcon = new Image();
-            tempIcon.imageSource = imageSource.fromResource(String(value));
-            value = tempIcon;
+            value = imageSource.fromResource(String(value));
         }
         this._icon = value;
-        this._ios.icon = (value) ? this._icon.ios.image : null;
+        this._ios.icon = (value) ? this._icon.ios : null;
     }
 
     get alpha() {


### PR DESCRIPTION
Unfortunately the improvement introduced in tns-core-modules@3.1.0 requires some more initialization on the `Image` to get the actual native instance. Reviewing the code only the `ImageSource` is retrieved from the `Image`, so I replaced the `Image` with `ImageSource` only which also removes some overhead. 

Unfortunately this is a breaking change but better now then not...