### PR TITLE
perf: Elimination of memory leaks

### DIFF
--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -41,6 +41,14 @@ export class MapView extends MapViewBase {
         application.android.off(application.AndroidApplication.activityDestroyedEvent, this.onActivityDestroyed, this);
     }
 
+    public disposeNativeView () {
+        this._context = undefined;
+        this._gMap = undefined;
+        this._markers = undefined;
+        this._shapes = undefined;
+        super.disposeNativeView();
+    };
+
     private onActivityPaused(args) {
         if (!this.nativeView || this._context != args.activity) return;
         this.nativeView.onPause();

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -9,6 +9,7 @@ import { Color } from "tns-core-modules/color";
 import * as imageSource from 'tns-core-modules/image-source';
 import { Point } from "tns-core-modules/ui/core/view";
 import { Image } from "tns-core-modules/ui/image";
+import { GC } from "utils/utils"
 
 declare class GMSMapViewDelegate extends NSObject {};
 declare class GMSCameraPosition extends NSObject {
@@ -197,6 +198,13 @@ export class MapView extends MapViewBase {
         this.nativeView.delegate = null;
         super.onUnloaded();
     }
+
+    public disposeNativeView () {
+        this._markers = null;
+        this._delegate = null;
+        super.disposeNativeView();
+        GC();
+    };
 
     private _createCameraPosition() {
         return GMSCameraPosition.cameraWithLatitudeLongitudeZoomBearingViewingAngle(


### PR DESCRIPTION
The application with two screens.
Switching between screens considerably increases busy memory application (from 50 to 100 Mb), in case of return on the first screen it is released not directly, and after some time, repeated opening of the second screen increases busy memory again and so on, as a result consuming of memory reaches some limit when application falls.

I created earlier issue where I explicitly described a problem https://github.com/NativeScript/NativeScript/issues/4889

The issue was closed with the response which did not solve a problem. Having carried out more detailed analysis I revealed that the forced call of GC in iOS released memory at once on closing of the screen with a map (as well as in native application)