### PR TITLE
Added a property control whether the map should use viewport animations.

### DIFF
--- a/map-view-common.ts
+++ b/map-view-common.ts
@@ -11,18 +11,18 @@ import frame = require("ui/frame");
 
 import { Property } from "tns-core-modules/ui/core/properties";
 import { Color } from "tns-core-modules/color";
-import {parseMultipleTemplates, parse} from "tns-core-modules/ui/builder";
-import {eachDescendant} from "tns-core-modules/ui/core/view-base";
-import {ProxyViewContainer} from "tns-core-modules/ui/proxy-view-container";
-import {StackLayout} from "tns-core-modules/ui/layouts/stack-layout";
+import { parseMultipleTemplates, parse } from "tns-core-modules/ui/builder";
+import { eachDescendant } from "tns-core-modules/ui/core/view-base";
+import { ProxyViewContainer } from "tns-core-modules/ui/proxy-view-container";
+import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
 
 function onInfoWindowTemplatesChanged(mapView: MapViewBase) {
     let _infoWindowTemplates = new Array<KeyedTemplate>();
 
     if (mapView.infoWindowTemplates && typeof mapView.infoWindowTemplates === "string") {
         _infoWindowTemplates = _infoWindowTemplates.concat(parseMultipleTemplates(mapView.infoWindowTemplates));
-    } else if(mapView.infoWindowTemplates) {
-        _infoWindowTemplates = _infoWindowTemplates.concat(<KeyedTemplate[]> mapView.infoWindowTemplates);
+    } else if (mapView.infoWindowTemplates) {
+        _infoWindowTemplates = _infoWindowTemplates.concat(<KeyedTemplate[]>mapView.infoWindowTemplates);
     }
 
     mapView._infoWindowTemplates = _infoWindowTemplates;
@@ -100,9 +100,9 @@ export module knownMultiTemplates {
     export const infoWindowTemplates = "infoWindowTemplates";
 }
 
-export function getColorHue(color: Color|string|number): number {
+export function getColorHue(color: Color | string | number): number {
     if (typeof color === 'number') {
-        while ( color < 0) { color += 360; }
+        while (color < 0) { color += 360; }
         return color % 360;
     }
     if (typeof color === 'string') color = new Color(color);
@@ -146,6 +146,7 @@ export abstract class MapViewBase extends View implements MapView {
     public zoom: number;
     public tilt: number;
     public padding: number[];
+    public mapAnimationsEnabled: boolean;
 
     public infoWindowTemplate: string | Template;
     public infoWindowTemplates: string | Array<KeyedTemplate>;
@@ -166,7 +167,7 @@ export abstract class MapViewBase extends View implements MapView {
 
     public static mapReadyEvent: string = "mapReady";
     public static markerSelectEvent: string = "markerSelect";
-    public static markerInfoWindowTappedEvent:string = "markerInfoWindowTapped";
+    public static markerInfoWindowTappedEvent: string = "markerInfoWindowTapped";
     public static shapeSelectEvent: string = "shapeSelect";
     public static markerBeginDraggingEvent: string = "markerBeginDragging";
     public static markerEndDraggingEvent: string = "markerEndDragging";
@@ -187,7 +188,7 @@ export abstract class MapViewBase extends View implements MapView {
     public _getMarkerInfoWindowContent(marker: MarkerBase) {
         var view;
 
-        if(marker && marker._infoWindowView) {
+        if (marker && marker._infoWindowView) {
             view = marker._infoWindowView;
             return view;
         }
@@ -238,7 +239,7 @@ export abstract class MapViewBase extends View implements MapView {
         return this._defaultInfoWindowTemplate;
     }
 
-    public abstract findMarker(callback: (marker: Marker)=>boolean): Marker;
+    public abstract findMarker(callback: (marker: Marker) => boolean): Marker;
 
     public abstract addPolyline(shape: Polyline): void;
 
@@ -341,10 +342,10 @@ export abstract class MapViewBase extends View implements MapView {
     }
 }
 
-export const infoWindowTemplateProperty = new Property<MapViewBase, string | Template>({name: "infoWindowTemplate"});
+export const infoWindowTemplateProperty = new Property<MapViewBase, string | Template>({ name: "infoWindowTemplate" });
 infoWindowTemplateProperty.register(MapViewBase);
 
-export const infoWindowTemplatesProperty = new Property<MapViewBase, string | Array<KeyedTemplate>>({name: "infoWindowTemplates", valueChanged: onInfoWindowTemplatesChanged })
+export const infoWindowTemplatesProperty = new Property<MapViewBase, string | Array<KeyedTemplate>>({ name: "infoWindowTemplates", valueChanged: onInfoWindowTemplatesChanged })
 infoWindowTemplatesProperty.register(MapViewBase);
 
 export const latitudeProperty = new Property<MapViewBase, number>({ name: 'latitude', defaultValue: 0, valueChanged: onMapPropertyChanged });
@@ -365,6 +366,9 @@ tiltProperty.register(MapViewBase);
 export const paddingProperty = new Property<MapViewBase, number[]>({ name: 'padding', valueChanged: onPaddingPropertyChanged, valueConverter: paddingValueConverter });
 paddingProperty.register(MapViewBase);
 
+export const mapAnimationsEnabledProperty = new Property<MapViewBase, boolean>({ name: 'mapAnimationsEnabled', defaultValue: true, valueChanged: onMapPropertyChanged });
+mapAnimationsEnabledProperty.register(MapViewBase);
+
 export class UISettingsBase implements UISettings {
     compassEnabled: boolean;
     indoorLevelPickerEnabled: boolean;
@@ -378,7 +382,7 @@ export class UISettingsBase implements UISettings {
 }
 
 export abstract class ProjectionBase implements Projection {
-    public visibleRegion : VisibleRegion;
+    public visibleRegion: VisibleRegion;
     public abstract fromScreenLocation(point: Point): Position;
     public abstract toScreenLocation(position: Position): Point;
     public ios: any; /* GMSProjection */
@@ -414,8 +418,8 @@ export abstract class MarkerBase implements Marker {
     public anchor: Array<number>;
     public title: string;
     public snippet: string;
-    public color: Color|string|number;
-    public icon: Image|string;
+    public color: Color | string | number;
+    public icon: Image | string;
     public alpha: number;
     public flat: boolean;
     public draggable: boolean;

--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -43,7 +43,7 @@ export class MapView extends MapViewBase {
         application.android.off(application.AndroidApplication.activityDestroyedEvent, this.onActivityDestroyed, this);
     }
 
-    public disposeNativeView () {
+    public disposeNativeView() {
         this._context = undefined;
         this._gMap = undefined;
         this._markers = undefined;
@@ -126,7 +126,7 @@ export class MapView extends MapViewBase {
                 gMap.setOnMyLocationButtonClickListener(new com.google.android.gms.maps.GoogleMap.OnMyLocationButtonClickListener({
                     onMyLocationButtonClick: () => {
                         owner.notifyMyLocationTapped();
-                        
+
                         return false;
                     }
                 }));
@@ -235,11 +235,11 @@ export class MapView extends MapViewBase {
 
                 gMap.setInfoWindowAdapter(new com.google.android.gms.maps.GoogleMap.InfoWindowAdapter({
 
-                    getInfoWindow : function(gmsMarker) {
+                    getInfoWindow: function (gmsMarker) {
                         return null;
                     },
 
-                    getInfoContents : function(gmsMarker) {
+                    getInfoContents: function (gmsMarker) {
                         let marker: Marker = owner.findMarker((marker: Marker) => marker.android.getId() === gmsMarker.getId());
                         var content = owner._getMarkerInfoWindowContent(marker);
                         return (content) ? content.android : null;
@@ -294,10 +294,14 @@ export class MapView extends MapViewBase {
         this._pendingCameraUpdate = false;
 
         var cameraUpdate = com.google.android.gms.maps.CameraUpdateFactory.newCameraPosition(cameraPosition);
-        this.gMap.animateCamera(cameraUpdate);
+        if (this.mapAnimationsEnabled) {
+            this.gMap.animateCamera(cameraUpdate);
+        } else {
+            this.gMap.moveCamera(cameraUpdate);
+        }
     }
 
-    setViewport(bounds:Bounds, padding?:number) {
+    setViewport(bounds: Bounds, padding?: number) {
         var p = padding || 0;
         var cameraUpdate = com.google.android.gms.maps.CameraUpdateFactory.newLatLngBounds(bounds.android, p);
         if (!this.gMap) {
@@ -306,7 +310,11 @@ export class MapView extends MapViewBase {
         }
 
         this._pendingCameraUpdate = false;
-        this.gMap.animateCamera(cameraUpdate);
+        if (this.mapAnimationsEnabled) {
+            this.gMap.animateCamera(cameraUpdate);
+        } else {
+            this.gMap.moveCamera(cameraUpdate);
+        }
     }
 
     updatePadding() {
@@ -576,7 +584,7 @@ export class Position extends PositionBase {
     }
 
     set latitude(latitude: number) {
-        this._android = new com.google.android.gms.maps.model.LatLng(parseFloat(""+latitude), this.longitude);
+        this._android = new com.google.android.gms.maps.model.LatLng(parseFloat("" + latitude), this.longitude);
     }
 
     get longitude() {
@@ -584,7 +592,7 @@ export class Position extends PositionBase {
     }
 
     set longitude(longitude: number) {
-        this._android = new com.google.android.gms.maps.model.LatLng(this.latitude, parseFloat(""+longitude));
+        this._android = new com.google.android.gms.maps.model.LatLng(this.latitude, parseFloat("" + longitude));
     }
 
     constructor(android?: any) {
@@ -619,7 +627,7 @@ export class Bounds extends BoundsBase {
         this._android = android;
     }
 
-    public static fromCoordinates(southwest:Position, northeast:Position): Bounds {
+    public static fromCoordinates(southwest: Position, northeast: Position): Bounds {
         return new Bounds(new com.google.android.gms.maps.model.LatLngBounds(southwest.android, northeast.android));
     }
 }
@@ -718,7 +726,7 @@ export class Marker extends MarkerBase {
         return this._color;
     }
 
-    set color(value: Color|string|number) {
+    set color(value: Color | string | number) {
         value = getColorHue(value);
 
         this._color = value;
@@ -735,7 +743,7 @@ export class Marker extends MarkerBase {
         return this._icon;
     }
 
-    set icon(value: Image|string) {
+    set icon(value: Image | string) {
         if (typeof value === 'string') {
             var tempIcon = new Image();
             tempIcon.imageSource = imageSource.fromResource(String(value));

--- a/map-view.d.ts
+++ b/map-view.d.ts
@@ -20,18 +20,19 @@ export class MapView extends View {
     public bearing: number;
     public tilt: number;
     public padding: number[];
+    public mapAnimationsEnabled: boolean;
 
     public notifyMapReady(): void;
 
     public updateCamera(): void;
 
-    public setViewport(bounds:Bounds, padding?:number): void;
+    public setViewport(bounds: Bounds, padding?: number): void;
 
     public updatePadding(): void;
 
     public static mapReadyEvent: string;
     public static markerSelectEvent: string;
-    public static markerInfoWindowTapEvent:string;
+    public static markerInfoWindowTapEvent: string;
     public static shapeSelectEvent: string;
     public static markerBeginDraggingEvent: string;
     public static markerEndDraggingEvent: string;
@@ -107,7 +108,7 @@ export class UISettings {
 }
 
 export class Projection {
-    public visibleRegion : VisibleRegion;
+    public visibleRegion: VisibleRegion;
     public fromScreenLocation(point: Point): Position;
     public toScreenLocation(position: Position): Point;
     public ios: any; /* GMSProjection */
@@ -135,7 +136,7 @@ export class Bounds {
     public southwest: Position;
     public ios: any; /* GMSCoordinateBounds */
     public android: any;
-    public static fromCoordinates(southwest:Position, northeast:Position): Bounds;
+    public static fromCoordinates(southwest: Position, northeast: Position): Bounds;
 }
 
 export class Marker {
@@ -144,8 +145,8 @@ export class Marker {
     public anchor: Array<number>;
     public title: string;
     public snippet: string;
-    public color: Color|string|number; /* Default Icon color - either Color, string color name, string color hex, or number hue (0-360) */
-    public icon: Image|string;
+    public color: Color | string | number; /* Default Icon color - either Color, string color name, string color hex, or number hue (0-360) */
+    public icon: Image | string;
     public alpha: number;
     public flat: boolean;
     public draggable: boolean;

--- a/map-view.ios.ts
+++ b/map-view.ios.ts
@@ -13,7 +13,7 @@ import { GC } from "utils/utils"
 
 export * from "./map-view-common";
 
-declare class GMSMapViewDelegate extends NSObject {};
+declare class GMSMapViewDelegate extends NSObject { };
 declare class GMSCameraPosition extends NSObject {
     target: any;
     bearing: any;
@@ -27,7 +27,7 @@ declare class GMSMapView extends NSObject {
 declare class GMSMarker extends NSObject {
     public static markerImageWithColor(color: UIColor): any;
 };
-declare class GMSOverlay extends NSObject {};
+declare class GMSOverlay extends NSObject { };
 declare class GMSMapStyle extends NSObject {
     public static styleWithJSONStringError(input: string): GMSMapStyle;
 };
@@ -39,9 +39,9 @@ declare class GMSCoordinateBounds extends NSObject {
     public southWest: CLLocationCoordinate2D;
     public valid: boolean;
 };
-declare class GMSPolyline extends NSObject {};
-declare class GMSPolygon extends NSObject {};
-declare class GMSCircle extends NSObject {};
+declare class GMSPolyline extends NSObject { };
+declare class GMSPolygon extends NSObject { };
+declare class GMSCircle extends NSObject { };
 declare class GMSMutablePath extends NSObject {
     public static new(): GMSMutablePath
     public addCoordinate(...params: any[]): void
@@ -180,15 +180,15 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
 
     public mapViewMarkerInfoContents(mapView: GMSMapView, gmsMarker: GMSMarker): UIView {
         let owner = this._owner.get();
-        if(!owner) return null;
+        if (!owner) return null;
         let marker: Marker = owner.findMarker((marker: Marker) => marker.ios == gmsMarker);
         var content = owner._getMarkerInfoWindowContent(marker);
 
         if (content) {
             let width = Number(content.width);
-            if ( Number.isNaN(width) ) width = null;
+            if (Number.isNaN(width)) width = null;
             let height = Number(content.height);
-            if ( Number.isNaN(height) ) height = null;
+            if (Number.isNaN(height)) height = null;
 
             if (!height || !width) {
                 const bounds: CGRect = require("utils/utils").ios.getter(UIScreen, UIScreen.mainScreen).bounds;
@@ -230,7 +230,7 @@ export class MapView extends MapViewBase {
         super.onUnloaded();
     }
 
-    public disposeNativeView () {
+    public disposeNativeView() {
         this._markers = null;
         this._delegate = null;
         super.disposeNativeView();
@@ -248,13 +248,22 @@ export class MapView extends MapViewBase {
     }
 
     updateCamera() {
-        this.nativeView.animateToCameraPosition(this._createCameraPosition());
+        if (this.mapAnimationsEnabled) {
+            this.nativeView.animateToCameraPosition(this._createCameraPosition());
+        } else {
+            this.nativeView.setCamera(this._createCameraPosition());
+        }
     }
 
     setViewport(bounds: Bounds, padding?: number) {
         var p = UIEdgeInsetsMake(padding, padding, padding, padding) || this.gMap.padding;
         let cameraPosition = this.nativeView.cameraForBoundsInsets(bounds.ios, p);
-        this.nativeView.animateToCameraPosition(cameraPosition);
+
+        if (this.mapAnimationsEnabled) {
+            this.nativeView.animateToCameraPosition(cameraPosition);
+        } else {
+            this.nativeView.setCamera(cameraPosition);
+        }
     }
 
     updatePadding() {
@@ -360,7 +369,7 @@ export class MapView extends MapViewBase {
         try {
             this.nativeView.mapStyle = GMSMapStyle.styleWithJSONStringError(JSON.stringify(style));
             return true;
-        } catch(err) {
+        } catch (err) {
             return false;
         }
     }
@@ -531,7 +540,7 @@ export class Bounds extends BoundsBase {
         this._ios = ios;
     }
 
-    public static fromCoordinates(southwest:Position, northeast:Position): Bounds {
+    public static fromCoordinates(southwest: Position, northeast: Position): Bounds {
         return new Bounds(GMSCoordinateBounds.alloc().initWithCoordinateCoordinate(southwest.ios, northeast.ios));
     }
 }
@@ -558,7 +567,7 @@ export class Position extends PositionBase {
         this._ios = CLLocationCoordinate2DMake(this.latitude, longitude);
     }
 
-    constructor(ios?:CLLocationCoordinate2D) {
+    constructor(ios?: CLLocationCoordinate2D) {
         super();
         this._ios = ios || CLLocationCoordinate2DMake(0, 0);
     }
@@ -639,7 +648,7 @@ export class Marker extends MarkerBase {
         return this._color;
     }
 
-    set color(value: Color|string|number) {
+    set color(value: Color | string | number) {
         value = getColorHue(value);
 
         this._color = value;
@@ -654,7 +663,7 @@ export class Marker extends MarkerBase {
         return this._icon;
     }
 
-    set icon(value: Image|string) {
+    set icon(value: Image | string) {
         if (typeof value === 'string') {
             var tempIcon = new Image();
             tempIcon.imageSource = imageSource.fromResource(String(value));
@@ -670,7 +679,7 @@ export class Marker extends MarkerBase {
 
     set alpha(value: number) {
         this._alpha = value;
-        if(this._visible) this._ios.opacity = value;
+        if (this._visible) this._ios.opacity = value;
     }
 
     get visible() {
@@ -739,7 +748,7 @@ export class Polyline extends PolylineBase {
 
     loadPoints(): void {
         var points = GMSMutablePath.new();
-        this._points.forEach(function(point) {
+        this._points.forEach(function (point) {
             points.addCoordinate(point.ios);
         }.bind(this));
         this._ios.path = points;
@@ -810,7 +819,7 @@ export class Polygon extends PolygonBase {
 
     loadPoints(): void {
         var points = GMSMutablePath.new();
-        this._points.forEach(function(point) {
+        this._points.forEach(function (point) {
             points.addCoordinate(point.ios);
         }.bind(this));
         this._ios.path = points;


### PR DESCRIPTION
Added `mapAnimationsEnabled` property to control whether viewport should just snap to new position or animate to it.

Did not test the iOS version, as I do not have the tech to do so, but implemented it according to API docs.

Sorry for the few spacing changes. My editor did it automatically on save.