### PR TITLE
Added ondestroy call to dispose nativeview method.

### DIFF
--- a/map-view.android.ts
+++ b/map-view.android.ts
@@ -44,6 +44,13 @@ export class MapView extends MapViewBase {
     }
 
     public disposeNativeView() {
+        if(this.nativeView){
+            this.nativeView.onDestroy();
+        }
+        if(this._gMap){
+            this._gMap.setMyLocationEnabled(false);
+            this._gMap.clear();
+        }
         this._context = undefined;
         this._gMap = undefined;
         this._markers = undefined;


### PR DESCRIPTION
This commit fixes the crash that occurs when navigating back and forth from and to a map view on a physical device multiple times.