### PR TITLE
feat(ios): add icon cache for icons with equivalent hues

### DIFF
--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -602,6 +602,17 @@ export class Marker extends MarkerBase {
     private _alpha = 1;
     private _visible = true;
 
+    private static cachedColorIcons: { [hue: number]: any } = {}
+
+    private static getIconForColor(hue: number) {
+        const hueKey = hue.toFixed(8);
+        if (!Marker.cachedColorIcons[hueKey]) {
+            const icon = GMSMarker.markerImageWithColor(UIColor.colorWithHueSaturationBrightnessAlpha(hue, 1, 1, 1));
+            Marker.cachedColorIcons[hueKey] = icon;
+        }
+        return Marker.cachedColorIcons[hueKey];
+    }
+
     constructor() {
         super();
         this._ios = GMSMarker.new();
@@ -668,7 +679,7 @@ export class Marker extends MarkerBase {
 
         this._color = value;
         if (this._color) {
-            this._ios.icon = GMSMarker.markerImageWithColor(UIColor.colorWithHueSaturationBrightnessAlpha(this._color / 360, 1, 1, 1));
+            this._ios.icon = Marker.getIconForColor(this._color / 360);
         } else {
             this._ios.icon = null;
         }


### PR DESCRIPTION
Currently, a new native marker image instance is created (via `GMSMarker.markerImageWithColor`) for each `Marker` instance created, even when the colors are equivalent. This causes issues when large amounts of markers are used. Anecdotally, I found that at around 800 marker instances caused error messages on iOS reading "((null)) was false: Reached the max number of texture atlases, can not allocate more."

This PR introduces a cache for icons created with colors so that resource are reused in the case that colors are equivalent. You can test that this is functioning with the following snippet added to the `onMapReady` function in the demo:

        marker.color = '#ff0000';
        const marker2 = new Marker();
        marker2.position = Position.positionFromLatLng(-33.96, 151.10);
        marker2.title = "Sydney";
        marker2.snippet = "Australia";
        marker2.userData = { index: 2 };
        marker2.color = '#ff0000';
        this.mapView.addMarker(marker);
        this.mapView.addMarker(marker2);
        console.log(marker.ios.icon === marker2.ios.icon); // true. Changing one marker's color property logs false

This PR only addresses iOS, though a similar cache could probably be implemented for Android. I have found that my app performs better and now displays over 1000 markers without issue after implementing this. 