### PR TITLE
feat: support for holes in polygons

### DIFF
--- a/src/map-view-common.ts
+++ b/src/map-view-common.ts
@@ -503,6 +503,7 @@ export abstract class PolygonBase extends ShapeBase implements Polygon {
     public shape: string = 'polygon';
     public _map: any;
     public _points: Array<PositionBase>;
+    public _holes: Array<Array<PositionBase>>;
     public strokeWidth: number;
     public strokeColor: Color;
     public fillColor: Color;
@@ -534,7 +535,36 @@ export abstract class PolygonBase extends ShapeBase implements Polygon {
         return this._points.slice();
     }
 
+    addHole(hole: PositionBase[]): void {
+        this._holes.push(hole);
+        this.reloadHoles();
+    }
+
+    addHoles(holes: PositionBase[][]): void {
+        this._holes = this._holes.concat(holes);
+        this.reloadHoles();
+    }
+
+    removeHole(hole: PositionBase[]): void {
+        var index = this._holes.indexOf(hole);
+        if (index > -1) {
+            this._holes.splice(index, 1);
+            this.reloadHoles();
+        }
+    }
+
+    removeAllHoles(): void {
+        this._holes.length = 0;
+        this.reloadHoles();
+    }
+
+    getHoles(): Array<Array<PositionBase>> {
+        return this._holes.slice();
+    }
+
     public abstract reloadPoints(): void;
+
+    public abstract reloadHoles(): void;
 }
 
 export class CircleBase extends ShapeBase implements Circle {

--- a/src/map-view.android.ts
+++ b/src/map-view.android.ts
@@ -417,6 +417,7 @@ export class MapView extends MapViewBase {
 
     addPolygon(shape: Polygon) {
         shape.loadPoints();
+        shape.loadHoles();
         shape.android = this.gMap.addPolygon(shape.android);
         this._shapes.push(shape);
     }
@@ -985,6 +986,7 @@ export class Polygon extends PolygonBase {
         super();
         this.android = new com.google.android.gms.maps.model.PolygonOptions();
         this._points = [];
+        this._holes = [];
     }
 
     get clickable() {
@@ -1031,6 +1033,18 @@ export class Polygon extends PolygonBase {
         }
     }
 
+    loadHoles(): void {
+        if (!this._isReal) {
+            this._holes.forEach((hole: Position[]) => {
+                var points = new java.util.ArrayList();
+                hole.forEach((point: Position) => {
+                    points.add(point.android);
+                });
+                this._android.addHole(points);
+            });
+        }
+    }
+
     reloadPoints(): void {
         if (this._isReal) {
             var points = new java.util.ArrayList();
@@ -1038,6 +1052,20 @@ export class Polygon extends PolygonBase {
                 points.add(point.android);
             });
             this._android.setPoints(points);
+        }
+    }
+
+    reloadHoles(): void {
+        if (this._isReal) {
+            var holes = new java.util.ArrayList();
+            this._holes.forEach((hole) => {
+                var points = new java.util.ArrayList();
+                hole.forEach((point) => {
+                    points.add(point.android);
+                });
+                holes.add(points);
+            });
+            this._android.setHoles(holes);
         }
     }
 

--- a/src/map-view.d.ts
+++ b/src/map-view.d.ts
@@ -196,7 +196,12 @@ export class Polygon extends Shape {
     public addPoints(shapes: Position[]): void;
     public removePoint(shape: Position): void;
     public removeAllPoints(): void;
+    public addHole(hole: Position[]): void;
+    public addHoles(hole: Position[][]): void;
+    public removeHole(hole: Position[]): void;
+    public removeAllHoles(): void;
     public getPoints(): Array<Position>;
+    public getHoles(): Array<Array<Position>>;
 }
 
 export class Circle extends Shape {

--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -812,6 +812,7 @@ export class Polygon extends PolygonBase {
         super();
         this._ios = GMSPolygon.new();
         this._points = [];
+        this._holes = [];
     }
 
     get clickable() {
@@ -830,18 +831,32 @@ export class Polygon extends PolygonBase {
         this._ios.zIndex = value;
     }
 
-
-
     loadPoints(): void {
         var points = GMSMutablePath.new();
-        this._points.forEach(function (point) {
+        this._points.forEach((point: Position) => {
             points.addCoordinate(point.ios);
-        }.bind(this));
+        });
         this._ios.path = points;
+    }
+
+    loadHoles(): void {
+        var holes = [];
+        this._holes.forEach((hole: Position[]) => {
+            var points = GMSMutablePath.new();
+            hole.forEach((point: Position) => {
+                points.addCoordinate(point.ios);
+            });
+            holes.push(points);
+        });
+        this._ios.holes = holes;
     }
 
     reloadPoints(): void {
         this.loadPoints();
+    }
+
+    reloadHoles(): void {
+        this.loadHoles();
     }
 
     get strokeWidth() {


### PR DESCRIPTION
Closes #324 

Implements support for adding holes to polygons. See usage below.

```
const fillColor = new Color(50, 30, 50, 79);
const strokeColor = new Color('#1E324F');

const polygonCoords = [
  Position.positionFromLatLng(25.774, -80.190),
  Position.positionFromLatLng(18.466, -66.118),
  Position.positionFromLatLng(32.321, -64.757)
];
  
const holeCoords = [
  Position.positionFromLatLng(28.745, -70.579),
  Position.positionFromLatLng(29.570, -67.514),
  Position.positionFromLatLng(27.339, -66.668)
];

const polygon = new Polygon();
polygon.fillColor = fillColor;
polygon.strokeColor = strokeColor;
polygon.addPoints(polygonCoords);
polygon.addHole(holeCoords);

this.map.addPolygon(polygon);
```