### PR TITLE
Update map-view.android.ts

### DIFF
--- a/src/map-view.android.ts
+++ b/src/map-view.android.ts
@@ -946,7 +946,7 @@ export class Polyline extends PolylineBase {
     set color(value: Color) {
         this._color = value;
         if (this._isReal) {
-            this._android.setStrokeColor(value.android);
+            this._android.setColor(value.android);
         } else {
             this._android.color(value.android);
         }


### PR DESCRIPTION
Calling `polyline.color = new Color(MY_COLOR);` on a **Polyline** that has been added to a **MapView** results in the error `TypeError: this._android.setStrokeColor is not a function`.

Replicated the error in my project with this

`(polyline as any)._android.setStrokeColor(new Color(MY_COLOR).android);`

And resolved it with this

`(polyline as any)._android.setColor(new Color(MY_COLOR).android)`

[Google API Docs - Polyline.setColor](https://developers.google.com/android/reference/com/google/android/gms/maps/model/Polyline.html#setColor(int))