### PR TITLE
fix(declaration): marker info window tapped event property

### DIFF
--- a/src/map-view.d.ts
+++ b/src/map-view.d.ts
@@ -34,7 +34,7 @@ export class MapView extends View {
 
     public static mapReadyEvent: string;
     public static markerSelectEvent: string;
-    public static markerInfoWindowTapEvent: string;
+    public static markerInfoWindowTappedEvent: string;
     public static shapeSelectEvent: string;
     public static markerBeginDraggingEvent: string;
     public static markerEndDraggingEvent: string;


### PR DESCRIPTION
Property is named incorrectly. Accessing the property as is results in `undefined`.