### PR TITLE
Added  Move Started and Move Canceled Event, only for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Event          | Description
 `cameraChanged` | Fired after the camera has changed
 `cameraMoveStarted` | Fired while the camera start move
 `cameraMove` | Fired while the camera is moving
-`cameraMoveStopped` | Fired while the camera stop move
+`cameraMoveCanceled` | Fired while the camera stop/canceled move 
 
 
 The property `gMap` gives you access to the raw platform Map Object - see their SDK references for how to use them ( [iOS](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_map_view) | [Android](https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap) )

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ Event          | Description
 `markerEndDragging` | Fires when a marker ends dragging
 `markerInfoWindowTapped` | Fired on tapping Marker Info Window
 `cameraChanged` | Fired after the camera has changed
+`cameraMoveStarted` | Fired while the camera start move
 `cameraMove` | Fired while the camera is moving
+`cameraMoveStoped` | Fired while the camera stop move
 
 
 The property `gMap` gives you access to the raw platform Map Object - see their SDK references for how to use them ( [iOS](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_map_view) | [Android](https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap) )

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Event          | Description
 `cameraChanged` | Fired after the camera has changed
 `cameraMoveStarted` | Fired while the camera start move
 `cameraMove` | Fired while the camera is moving
-`cameraMoveStoped` | Fired while the camera stop move
+`cameraMoveStopped` | Fired while the camera stop move
 
 
 The property `gMap` gives you access to the raw platform Map Object - see their SDK references for how to use them ( [iOS](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_map_view) | [Android](https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap) )

--- a/src/map-view-common.ts
+++ b/src/map-view-common.ts
@@ -181,6 +181,8 @@ export abstract class MapViewBase extends View implements MapView {
     public static coordinateTappedEvent: string = "coordinateTapped";
     public static coordinateLongPressEvent: string = "coordinateLongPress";
     public static cameraChangedEvent: string = "cameraChanged";
+    public static cameraMoveStartedEvent: string = "cameraMoveStarted";
+    public static cameraMoveCanceledEvent: string = "cameraMoveCanceled";
     public static cameraMoveEvent: string = "cameraMove";
     public static myLocationTappedEvent: string = "myLocationTapped";
 

--- a/src/map-view.android.ts
+++ b/src/map-view.android.ts
@@ -256,6 +256,21 @@ export class MapView extends MapViewBase {
                     }));
                 }
 
+                if(gMap.setOnCameraMoveStartedListener){
+                    gMap.setOnCameraMoveStartedListener(new com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener({
+                        onCameraMoveStarted : function(reason){
+                            owner.notifyCameraEvent(MapViewBase.cameraMoveStartedEvent, reason);
+                        }
+                    }));
+                }
+                if(gMap.setOnCameraMoveCanceledListener){
+                    gMap.setOnCameraMoveCanceledListener(new com.google.android.gms.maps.GoogleMap.OnCameraMoveCanceledListener({
+                        onCameraMoveCanceled : function(){
+                            owner.notifyCameraEvent(MapViewBase.cameraMoveCanceledEvent, null);
+                        }
+                    }));
+                }
+                
                 gMap.setInfoWindowAdapter(new com.google.android.gms.maps.GoogleMap.InfoWindowAdapter({
 
                     getInfoWindow: function (gmsMarker) {


### PR DESCRIPTION
As GoogleMap documentation makes available in the links below, I added two more methods, one to monitor the camera's start of movement and what is its reason and another to alert its cancellation.

* https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap
* https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener
* https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveCanceledListener
* https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraChangeListener