### PR TITLE
fix: allow notifying of marker tap event (after #331)

### DIFF
--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -102,7 +102,11 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
             let marker: Marker = owner.findMarker((marker: Marker) => marker.ios == gmsMarker);
             if (marker) {
                 owner.notifyMarkerTapped(marker);
-                return true;
+
+                // move to end of event loop to allow notification to finish
+                setTimeout(() => {
+                    return true;
+                },0);
             }
         }
         return false;

--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -102,11 +102,6 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
             let marker: Marker = owner.findMarker((marker: Marker) => marker.ios == gmsMarker);
             if (marker) {
                 owner.notifyMarkerTapped(marker);
-
-                // move to end of event loop to allow notification to finish
-                setTimeout(() => {
-                    return true;
-                },0);
             }
         }
         return false;


### PR DESCRIPTION
PR #331 changed the `mapViewDidTapMarker` method where [this](https://github.com/dapriett/nativescript-google-maps-sdk/blob/master/src/map-view.ios.ts#L105) return prevents the InfoWindow from showing.