### PR TITLE
feat(ios): set ios nativeview in view lifecycle #398

### DIFF
--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -278,19 +278,11 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
 
 export class MapView extends MapViewBase {
 
+    public nativeView: GMSMapView;
     protected _markers: Array<Marker> = new Array<Marker>();
 
     private _delegate: MapViewDelegateImpl;
     private _indoorDelegate:IndoorDisplayDelegateImpl;
-
-    constructor() {
-        super();
-
-        this.nativeView = GMSMapView.mapWithFrameCamera(CGRectZero, this._createCameraPosition());
-        this._delegate = MapViewDelegateImpl.initWithOwner(new WeakRef(this));
-        this._indoorDelegate = IndoorDisplayDelegateImpl.initWithOwner(new WeakRef(this));
-        this.updatePadding();
-    }
 
     public onLoaded() {
         super.onLoaded();
@@ -313,6 +305,20 @@ export class MapView extends MapViewBase {
         GC();
     };
 
+    public createNativeView() {
+        const mapView = GMSMapView.mapWithFrameCamera(CGRectZero, this._createCameraPosition());
+        this._delegate = MapViewDelegateImpl.initWithOwner(new WeakRef(this));
+        this._indoorDelegate = IndoorDisplayDelegateImpl.initWithOwner(new WeakRef(this));
+        this.updatePadding();
+
+        return mapView;
+    }
+
+    public initNativeView() {
+        (<any>this.nativeView).owner = this;
+        super.initNativeView();
+    }
+
     private _createCameraPosition() {
         return GMSCameraPosition.cameraWithLatitudeLongitudeZoomBearingViewingAngle(
             this.latitude,
@@ -324,10 +330,12 @@ export class MapView extends MapViewBase {
     }
 
     updateCamera() {
-        if (this.mapAnimationsEnabled) {
-            this.nativeView.animateToCameraPosition(this._createCameraPosition());
-        } else {
-            this.nativeView.camera = this._createCameraPosition();
+        if (this.nativeView) {
+            if (this.mapAnimationsEnabled) {
+                this.nativeView.animateToCameraPosition(this._createCameraPosition());
+            } else {
+                this.nativeView.camera = this._createCameraPosition();
+            }
         }
     }
 


### PR DESCRIPTION
Closes #398 

- Added `if(this.nativeView)` at the `updateCamera()` since that method is called from MapViewBase on property change - which is fired when setting the initial values.