### PR TITLE
fix: myLocationButton not working on iOS

### DIFF
--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -216,7 +216,6 @@ class MapViewDelegateImpl extends NSObject implements GMSMapViewDelegate {
         const owner = this._owner.get();
         if (owner) {
             owner.notifyMyLocationTapped();
-            return true;
         }
         return false;
     }


### PR DESCRIPTION
Closes #375 
identical fix as PR #369 

fix: return true in didTapMyLocationButtonForMapView prevents the default behavior of the myLocationButton. So, the map does not move to myLocation on Tap. 