### PR TITLE
Remove source from podfile

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,3 +1,1 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
 pod 'GoogleMaps'


### PR DESCRIPTION
No need to specify source anymore. See https://blog.cocoapods.org/CocoaPods-1.7.2/

After installing this plugin, my `tns debug ios` command hung at 
```
Cloning spec repo `cocoapods` from `https://github.com/CocoaPods/Specs.git`
```

According to my colleague, it would finish after a 20 minute wait, but that's a bit long for us.