### PR TITLE
(android) [BUG]: Marker.icon uses deprecated fromResource() method

### DIFF
--- a/src/map-view.android.ts
+++ b/src/map-view.android.ts
@@ -10,7 +10,7 @@ import {
 import { Image } from "tns-core-modules/ui/image";
 import { Color } from "tns-core-modules/color";
 import { Point } from "tns-core-modules/ui/core/view";
-import imageSource = require("tns-core-modules/image-source");
+import { ImageSource } from "tns-core-modules/image-source";
 import {IndoorLevel} from "./map-view";
 
 export * from "./map-view-common";
@@ -834,7 +834,7 @@ export class Marker extends MarkerBase {
     set icon(value: Image | string) {
         if (typeof value === 'string') {
             var tempIcon = new Image();
-            tempIcon.imageSource = imageSource.fromResource(String(value));
+            tempIcon.imageSource = ImageSource.fromResourceSync(String(value));
             value = tempIcon;
         }
         this._icon = value;


### PR DESCRIPTION
Marker.icon can't be set, because fromResource() is deprecated. Use ImageSource.fromResourceSync() instead.