### PR TITLE
(iOS) [BUG]: Marker.icon uses deprecated fromResource() method

### DIFF
--- a/src/map-view.ios.ts
+++ b/src/map-view.ios.ts
@@ -6,7 +6,7 @@ import {
     tiltProperty, StyleBase, UISettingsBase, getColorHue
 } from "./map-view-common";
 import { Color } from "tns-core-modules/color";
-import * as imageSource from 'tns-core-modules/image-source';
+import { ImageSource } from 'tns-core-modules/image-source';
 import { Point } from "tns-core-modules/ui/core/view";
 import { Image } from "tns-core-modules/ui/image";
 import { GC, layout } from "utils/utils"
@@ -767,7 +767,7 @@ export class Marker extends MarkerBase {
     set icon(value: Image | string) {
         if (typeof value === 'string') {
             var tempIcon = new Image();
-            tempIcon.imageSource = imageSource.fromResource(String(value));
+            tempIcon.imageSource = ImageSource.fromResourceSync(String(value));
             value = tempIcon;
         }
         this._icon = value;


### PR DESCRIPTION
Marker.icon can't be set, because fromResource() is deprecated. Use ImageSource.fromResourceSync() instead.